### PR TITLE
Chore platform 4

### DIFF
--- a/lib/mumukit/platform.rb
+++ b/lib/mumukit/platform.rb
@@ -17,9 +17,9 @@ module Mumukit::Platform
 
       config.laboratory_url = ENV['MUMUKI_LABORATORY_URL'] || "http://#{domain}"
       config.thesaurus_url = ENV['MUMUKI_THESAURUS_URL'] || "http://thesaurus.#{domain}"
-      config.bibliotheca_url = ENV['MUMUKI_BIBLIOTHECA_URL'] || "http://bibliotheca.#{domain}"
+      config.bibliotheca_ui_url = ENV['MUMUKI_BIBLIOTHECA_UI_URL'] || "http://bibliotheca.#{domain}"
       config.bibliotheca_api_url = ENV['MUMUKI_BIBLIOTHECA_API_URL'] || "http://bibliotheca-api.#{domain}"
-      config.classroom_url = ENV['MUMUKI_CLASSROOM_URL'] || "http://classroom.#{domain}"
+      config.classroom_ui_url = ENV['MUMUKI_CLASSROOM_UI_URL'] || "http://classroom.#{domain}"
       config.classroom_api_url = ENV['MUMUKI_CLASSROOM_API_URL'] || "http://classroom-api.#{domain}"
       config.organization_mapping = Mumukit::Platform::OrganizationMapping.from_env
     end

--- a/lib/mumukit/platform/course/helpers.rb
+++ b/lib/mumukit/platform/course/helpers.rb
@@ -20,10 +20,10 @@ module Mumukit::Platform::Course::Helpers
     slug
   end
 
-  ## Platform JSON
+  ## Resource Hash
 
-  def self.slice_platform_json(json)
-    json.slice(:slug, :shifts, :code, :days, :period, :description)
+  def self.slice_resource_h(resource_h)
+    resource_h.slice(:slug, :shifts, :code, :days, :period, :description)
   end
 
   def to_resource_h
@@ -34,10 +34,10 @@ module Mumukit::Platform::Course::Helpers
       days: days,
       period: period,
       description: description
-    }.except(*protected_platform_fields).compact
+    }.except(*protected_resource_fields).compact
   end
 
-  def protected_platform_fields
+  def protected_resource_fields
     []
   end
 end

--- a/lib/mumukit/platform/organization/helpers.rb
+++ b/lib/mumukit/platform/organization/helpers.rb
@@ -76,10 +76,10 @@ module Mumukit::Platform::Organization::Helpers
     /([-a-z0-9_]+(\.[-a-z0-9_]+)*)?/
   end
 
-  ## Platform JSON
+  ## Resource Hash
 
-  def self.slice_platform_json(json)
-    json.slice(:name, :book, :profile, :settings, :theme)
+  def self.slice_resource_h(resource_h)
+    resource_h.slice(:name, :book, :profile, :settings, :theme)
   end
 
   def to_resource_h
@@ -89,10 +89,10 @@ module Mumukit::Platform::Organization::Helpers
       profile: profile,
       settings: settings,
       theme: theme
-    }.except(*protected_platform_fields).compact
+    }.except(*protected_resource_fields).compact
   end
 
-  def protected_platform_fields
+  def protected_resource_fields
     []
   end
 

--- a/lib/mumukit/platform/user/helpers.rb
+++ b/lib/mumukit/platform/user/helpers.rb
@@ -95,10 +95,10 @@ module Mumukit::Platform::User::Helpers
     uid
   end
 
-  ## Platform JSON
+  ## Resource Hash
 
-  def self.slice_platform_json(json)
-    json.slice(:uid, :social_id, :image_url, :email, :first_name, :last_name, :permissions)
+  def self.slice_resource_h(resource_h)
+    resource_h.slice(:uid, :social_id, :image_url, :email, :first_name, :last_name, :permissions)
   end
 
   def to_resource_h
@@ -110,10 +110,10 @@ module Mumukit::Platform::User::Helpers
       first_name: first_name,
       last_name: last_name,
       permissions: permissions
-    }.except(*protected_platform_fields).compact
+    }.except(*protected_resource_fields).compact
   end
 
-  def protected_platform_fields
+  def protected_resource_fields
     []
   end
 end

--- a/lib/mumukit/platform/with_applications.rb
+++ b/lib/mumukit/platform/with_applications.rb
@@ -1,6 +1,5 @@
 module Mumukit::Platform::WithApplications
   delegate :application, to: :config
-  delegate :url_for, :organic_url_for, to: :application
 
   def laboratory
     Mumukit::Platform::Application::Organic.new config.laboratory_url, organization_mapping

--- a/lib/mumukit/platform/with_applications.rb
+++ b/lib/mumukit/platform/with_applications.rb
@@ -6,16 +6,16 @@ module Mumukit::Platform::WithApplications
     Mumukit::Platform::Application::Organic.new config.laboratory_url, organization_mapping
   end
 
-  def classroom
-    Mumukit::Platform::Application::Organic.new config.classroom_url, organization_mapping
+  def classroom_ui
+    Mumukit::Platform::Application::Organic.new config.classroom_ui_url, organization_mapping
   end
 
   def classroom_api
     Mumukit::Platform::Application::Organic.new config.classroom_api_url, organization_mapping
   end
 
-  def bibliotheca
-    Mumukit::Platform::Application::Basic.new config.bibliotheca_url
+  def bibliotheca_ui
+    Mumukit::Platform::Application::Basic.new config.bibliotheca_ui_url
   end
 
   def bibliotheca_api

--- a/spec/mumukit/application_spec.rb
+++ b/spec/mumukit/application_spec.rb
@@ -6,8 +6,8 @@ describe Mumukit::Platform::Application do
   it { expect(Mumukit::Platform.bibliotheca_ui.url).to eq 'http://bibliotheca.localmumuki.io' }
   it { expect(Mumukit::Platform.bibliotheca_ui.domain).to eq 'bibliotheca.localmumuki.io' }
 
-  it { expect(Mumukit::Platform.url_for '/bar').to eq 'http://sample.app.com/bar' }
-  it { expect(Mumukit::Platform.organic_url_for 'orga', '/bar').to eq 'http://orga.sample.app.com/bar' }
+  it { expect(Mumukit::Platform.application.url_for '/bar').to eq 'http://sample.app.com/bar' }
+  it { expect(Mumukit::Platform.application.organic_url_for 'orga', '/bar').to eq 'http://orga.sample.app.com/bar' }
 
   describe Mumukit::Platform::Application::Basic do
     context 'with subdomain mapping strategy' do

--- a/spec/mumukit/application_spec.rb
+++ b/spec/mumukit/application_spec.rb
@@ -2,9 +2,9 @@ require_relative '../spec_helper'
 
 describe Mumukit::Platform::Application do
   it { expect(Mumukit::Platform.laboratory.organic_url_for 'foo', '/foo/baz').to eq 'http://foo.localmumuki.io/foo/baz' }
-  it { expect(Mumukit::Platform.classroom.organic_url_for 'foo', '/foo/baz').to eq 'http://foo.classroom.localmumuki.io/foo/baz' }
-  it { expect(Mumukit::Platform.bibliotheca.url).to eq 'http://bibliotheca.localmumuki.io' }
-  it { expect(Mumukit::Platform.bibliotheca.domain).to eq 'bibliotheca.localmumuki.io' }
+  it { expect(Mumukit::Platform.classroom_ui.organic_url_for 'foo', '/foo/baz').to eq 'http://foo.classroom.localmumuki.io/foo/baz' }
+  it { expect(Mumukit::Platform.bibliotheca_ui.url).to eq 'http://bibliotheca.localmumuki.io' }
+  it { expect(Mumukit::Platform.bibliotheca_ui.domain).to eq 'bibliotheca.localmumuki.io' }
 
   it { expect(Mumukit::Platform.url_for '/bar').to eq 'http://sample.app.com/bar' }
   it { expect(Mumukit::Platform.organic_url_for 'orga', '/bar').to eq 'http://orga.sample.app.com/bar' }


### PR DESCRIPTION
Fixing naming inconsistencies in `mumuki-6` series in a non-backward-compatible way: 

* Renamed classroom and bibliotheca to classroom_ui and bibliotheca_ui
* Renamed remaining platform_json references to resource_h
* Removing implicit delegations to current application - which are error prone: apps code should always use its app-specific reference, only generic code should use the `application` config. 