### PR TITLE
Readd name validation for organizations

### DIFF
--- a/lib/mumukit/platform/organization.rb
+++ b/lib/mumukit/platform/organization.rb
@@ -23,5 +23,20 @@ module Mumukit::Platform::Organization
   def self.find_by_name!(name)
     Mumukit::Platform.organization_class.find_by_name!(name)
   end
+
+
+  ## Name validation
+
+  def self.valid_name?(name)
+    !!(name =~ anchored_valid_name_regex)
+  end
+
+  def self.anchored_valid_name_regex
+    /\A#{valid_name_regex}\z/
+  end
+
+  def self.valid_name_regex
+    /([-a-z0-9_]+(\.[-a-z0-9_]+)*)?/
+  end
 end
 

--- a/lib/mumukit/platform/web_framework.rb
+++ b/lib/mumukit/platform/web_framework.rb
@@ -21,7 +21,7 @@ module Mumukit::Platform::WebFramework
     def self.tenant_scope_options
       {
           defaults: { tenant: lazy_string { Mumukit::Platform.current_organization_name } },
-          constraints: { tenant: Mumukit::Platform::Organization::Helpers.valid_name_regex }
+          constraints: { tenant: Mumukit::Platform::Organization.valid_name_regex }
       }
     end
   end

--- a/spec/mumukit/organization_spec.rb
+++ b/spec/mumukit/organization_spec.rb
@@ -1,0 +1,16 @@
+describe Mumukit::Platform::Organization do
+  describe '#valid_name?' do
+    def valid_name?(name)
+      Mumukit::Platform::Organization::valid_name? name
+    end
+
+    it { expect(valid_name? 'foo').to be true }
+    it { expect(valid_name? 'a.name').to be true }
+    it { expect(valid_name? 'a.name.with.subdomains').to be true }
+    it { expect(valid_name? '.a.name.that.starts.with.period').to be false }
+    it { expect(valid_name? 'a.name.that.ends.with.period.').to be false }
+    it { expect(valid_name? 'a.name.that..has.two.periods.in.a.row').to be false }
+    it { expect(valid_name? 'a.name.with.Uppercases').to be false }
+    it { expect(valid_name? 'A random name').to be false }
+  end
+end


### PR DESCRIPTION
Moving these name validation methods back from Domain, since they're used in Platform itself and we can't reference Domain here
