### PR TITLE
Feature current course

### DIFF
--- a/lib/mumukit/platform.rb
+++ b/lib/mumukit/platform.rb
@@ -51,6 +51,7 @@ end
 
 require_relative './platform/notifiable'
 
+require_relative './platform/global'
 require_relative './platform/domain'
 require_relative './platform/model'
 require_relative './platform/locale'

--- a/lib/mumukit/platform/course.rb
+++ b/lib/mumukit/platform/course.rb
@@ -1,5 +1,11 @@
 module Mumukit::Platform::Course
+  extend Mumukit::Platform::Global
+
   def self.find_by_slug!(slug)
     Mumukit::Platform.course_class.find_by_slug!(slug)
+  end
+
+  def self.__global_thread_variable_key__
+    :course
   end
 end

--- a/lib/mumukit/platform/global.rb
+++ b/lib/mumukit/platform/global.rb
@@ -1,0 +1,19 @@
+module Mumukit::Platform::Global
+  def switch!(global)
+    raise "#{__global_thread_variable_key__} must not be nil" unless global
+    Thread.current[__global_thread_variable_key__] = global
+  end
+
+  def leave!
+    Thread.current[__global_thread_variable_key__] = nil
+  end
+
+  def current
+    Thread.current[__global_thread_variable_key__] || raise("#{__global_thread_variable_key__} not selected")
+  end
+
+  def current?
+    !!Thread.current[__global_thread_variable_key__]
+  end
+end
+

--- a/lib/mumukit/platform/organization.rb
+++ b/lib/mumukit/platform/organization.rb
@@ -1,20 +1,5 @@
 module Mumukit::Platform::Organization
-  def self.switch!(organization)
-    raise 'Organization must not be nil' unless organization
-    Thread.current[:organization] = organization
-  end
-
-  def self.leave!
-    Thread.current[:organization] = nil
-  end
-
-  def self.current
-    Thread.current[:organization] || raise('organization not selected')
-  end
-
-  def self.current?
-    !!Thread.current[:organization]
-  end
+  extend Mumukit::Platform::Global
 
   def self.current_locale
     Thread.current[:organization]&.locale || 'en'
@@ -24,6 +9,9 @@ module Mumukit::Platform::Organization
     Mumukit::Platform.organization_class.find_by_name!(name)
   end
 
+  def self.__global_thread_variable_key__
+    :organization
+  end
 
   ## Name validation
 

--- a/spec/mumukit/course_spec.rb
+++ b/spec/mumukit/course_spec.rb
@@ -1,0 +1,24 @@
+describe Mumukit::Platform::Course do
+  let(:current) { Object.new }
+
+  describe 'current' do
+    context 'when not set' do
+      before { Mumukit::Platform::Course.leave! }
+      it { expect { Mumukit::Platform::Course.current }.to raise_error('course not selected') }
+      it { expect(Mumukit::Platform::Course.current?).to be false }
+    end
+
+    context 'when set' do
+      before { Mumukit::Platform::Course.switch! current }
+      it { expect(Mumukit::Platform::Course.current).to eq current }
+      it { expect(Mumukit::Platform::Course.current?).to be true }
+    end
+
+    context 'when set and reset' do
+      before { Mumukit::Platform::Course.switch! current }
+      before { Mumukit::Platform::Course.leave! }
+
+      it { expect(Mumukit::Platform::Course.current?).to be false }
+    end
+  end
+end

--- a/spec/mumukit/organization_spec.rb
+++ b/spec/mumukit/organization_spec.rb
@@ -1,4 +1,6 @@
 describe Mumukit::Platform::Organization do
+  let(:current) { Object.new }
+
   describe '#valid_name?' do
     def valid_name?(name)
       Mumukit::Platform::Organization::valid_name? name
@@ -12,5 +14,26 @@ describe Mumukit::Platform::Organization do
     it { expect(valid_name? 'a.name.that..has.two.periods.in.a.row').to be false }
     it { expect(valid_name? 'a.name.with.Uppercases').to be false }
     it { expect(valid_name? 'A random name').to be false }
+  end
+
+  describe 'current' do
+    context 'when not set' do
+      before { Mumukit::Platform::Organization.leave! }
+      it { expect { Mumukit::Platform::Organization.current }.to raise_error('organization not selected') }
+      it { expect(Mumukit::Platform::Organization.current?).to be false }
+    end
+
+    context 'when set' do
+      before { Mumukit::Platform::Organization.switch! current }
+      it { expect(Mumukit::Platform::Organization.current).to eq current }
+      it { expect(Mumukit::Platform::Organization.current?).to be true }
+    end
+
+    context 'when set and reset' do
+      before { Mumukit::Platform::Organization.switch! current }
+      before { Mumukit::Platform::Organization.leave! }
+
+      it { expect(Mumukit::Platform::Organization.current?).to be false }
+    end
   end
 end


### PR DESCRIPTION
# :dart: Goal

This PR adds support for having a global selected course, mimicking the organization interface. 

# :soon:  Future work

In the future, such `current_course` may be filled manually or using an specific logic, based on the permissions of the `current_user`


# :back: Backward compatibility

This PR is fully backward compatible. It adds a new feature, and should be introduced into a minor. 

# :eyes: See also

This feature is related to https://github.com/mumuki/mumuki-domain/pull/95, since that feature - and probably many others - would benefit of having a global course, and a `current_course` method. 
