### PR TITLE
using path_info from request env instead of path from request

### DIFF
--- a/lib/mumukit/platform/organization_mapping.rb
+++ b/lib/mumukit/platform/organization_mapping.rb
@@ -50,7 +50,7 @@ module Mumukit::Platform::OrganizationMapping
     end
 
     def self.organization_name(request, _domain)
-      request.path.split('/')[1]
+      request.path_info.split('/')[1]
     end
 
     def self.organic_uri(uri, organization)


### PR DESCRIPTION
I need to make that because when classroom engine routes are mounted it's necesary to exclude de mount point from the url. More info [here](https://www.rubydoc.info/github/rack/rack/file/SPEC)