### PR TITLE
Avoid caching classes in development mode

### DIFF
--- a/lib/mumukit/platform.rb
+++ b/lib/mumukit/platform.rb
@@ -42,10 +42,10 @@ module Mumukit::Platform
     define_singleton_method("#{klass}_class") do
       begin
         return config["#{klass}_class"] if config["#{klass}_class"].present?
-        config["#{klass}_class_name"].constantize.tap do |klass_instance|
+        config["#{klass}_class_name"].to_s.constantize.tap do |klass_instance|
           config["#{klass}_class"] = klass_instance unless %w(RACK_ENV RAILS_ENV).any? { |it| ENV[it] == 'development' }
         end
-      rescue
+      rescue NameError => e
         raise "You must configure your #{klass} class first"
       end
     end

--- a/lib/mumukit/platform.rb
+++ b/lib/mumukit/platform.rb
@@ -41,7 +41,10 @@ module Mumukit::Platform
     #
     define_singleton_method("#{klass}_class") do
       begin
-        config["#{klass}_class"] ||= config["#{klass}_class_name"].constantize
+        return config["#{klass}_class"] if config["#{klass}_class"].present?
+        config["#{klass}_class_name"].constantize.tap do |klass_instance|
+          config["#{klass}_class"] = klass_instance unless %w(RACK_ENV RAILS_ENV).any? { |it| ENV[it] == 'development' }
+        end
       rescue
         raise "You must configure your #{klass} class first"
       end


### PR DESCRIPTION
I need to do further research on this one and see if a better approach for solving this issue can be found.
I believe this one will fix all the `ActiveRecord::AssociationTypeMismatch` and all of the `A copy of xxx has been removed from the module tree but is still active`.

After several hours of reading and looking at out code, I ended up reaching this particular file that, among other things, allows to retrieve user, organization and course classes in platform from the proper model. To avoid actually constantizing several times, it was using memoization. The problem with that, is that in development mode, and for the happiness of the developer, rails reload classes that have changed, so that you always have the updated code without having to reload the server.
The main issue with that is that we were caching, for example, the old user class. So when the code was actually reloadad and we wanted to retrieve, for example, the `current_user`, it was obtained using an old instance of User class. Then, at some point, that user was used to instantiate or look for another model, and that ended up breaking, because rails associations always ensures that you are using the refreshed classes to avoid inconsistencies. 

Although it's not ready to merge (I think the solution is not the cleanest, and even if we do end up using it, it needs to be tested thoroughly) I encourage @mumuki/core-devs to use it when developing in the meanwhile, as as far as I've tested it does solve the issue.