### PR TITLE
Fix make fragment urls work

### DIFF
--- a/lib/mumukit/platform.rb
+++ b/lib/mumukit/platform.rb
@@ -17,9 +17,9 @@ module Mumukit::Platform
 
       config.laboratory_url = ENV['MUMUKI_LABORATORY_URL'] || "http://#{domain}"
       config.thesaurus_url = ENV['MUMUKI_THESAURUS_URL'] || "http://thesaurus.#{domain}"
-      config.bibliotheca_ui_url = ENV['MUMUKI_BIBLIOTHECA_UI_URL'] || "http://bibliotheca.#{domain}"
+      config.bibliotheca_ui_url = ENV['MUMUKI_BIBLIOTHECA_UI_URL'] || "http://bibliotheca.#{domain}/#/"
       config.bibliotheca_api_url = ENV['MUMUKI_BIBLIOTHECA_API_URL'] || "http://bibliotheca-api.#{domain}"
-      config.classroom_ui_url = ENV['MUMUKI_CLASSROOM_UI_URL'] || "http://classroom.#{domain}"
+      config.classroom_ui_url = ENV['MUMUKI_CLASSROOM_UI_URL'] || "http://classroom.#{domain}/#/"
       config.classroom_api_url = ENV['MUMUKI_CLASSROOM_API_URL'] || "http://classroom-api.#{domain}"
       config.organization_mapping = Mumukit::Platform::OrganizationMapping.from_env
     end

--- a/lib/mumukit/platform/application.rb
+++ b/lib/mumukit/platform/application.rb
@@ -28,7 +28,15 @@ class Mumukit::Platform::Application
   end
 
   def organic_url_for(organization, path)
-    organic_uri(organization).url_for(relative_path path)
+    uri = organic_uri(organization)
+    # warning: this code is thighly
+    # coupled to the fact that applications can only rebuild urls
+    # in fragmented-mode
+    if uri.fragment
+      uri.to_s + relative_path(path)
+    else
+      uri.url_for(relative_path path)
+    end
   end
 
   def relative_path(path)

--- a/lib/mumukit/platform/application.rb
+++ b/lib/mumukit/platform/application.rb
@@ -29,7 +29,7 @@ class Mumukit::Platform::Application
 
   def organic_url_for(organization, path)
     uri = organic_uri(organization)
-    # warning: this code is thighly
+    # warning: this code is tightly
     # coupled to the fact that applications can only rebuild urls
     # in fragmented-mode
     if uri.fragment

--- a/lib/mumukit/platform/organization_mapping.rb
+++ b/lib/mumukit/platform/organization_mapping.rb
@@ -42,7 +42,7 @@ module Mumukit::Platform::OrganizationMapping
     end
 
     def self.organic_uri(uri, organization)
-      uri.subdominate(organization)
+      uri.subdominate(organization, fragmented: true)
     end
 
     def self.path_under_namespace?(_organization_name, path, namespace)
@@ -79,7 +79,7 @@ module Mumukit::Platform::OrganizationMapping
     end
 
     def self.organic_uri(uri, organization)
-      uri.tenantize organization
+      uri.tenantize organization, fragmented: true
     end
 
     def self.path_under_namespace?(organization_name, path, namespace)

--- a/lib/mumukit/platform/uri.rb
+++ b/lib/mumukit/platform/uri.rb
@@ -1,23 +1,30 @@
 class URI::HTTP
-  def subdominate(subdomain)
+  def subdominate(subdomain, **options)
     if host.start_with? 'www.'
       new_host = host.gsub('www.', "www.#{subdomain}.")
     else
       new_host = "#{subdomain}.#{host}"
     end
-    rebuild(host: new_host)
+    rebuild({host: new_host}, **options)
   end
 
-  def tenantize(route)
+  def tenantize(route, **options)
     if path.end_with? '/'
       new_path = "#{path}#{route}/"
     else
       new_path = "#{path}/#{route}/"
     end
-    rebuild(path: new_path)
+    rebuild({path: new_path}, **options)
   end
 
-  def rebuild(updates)
+  def rebuild(updates, fragmented: false)
+    if fragmented && fragment
+      fragment = "#{self.fragment}/#{updates[:path]}/".squeeze('/')
+      updates = updates.except(:path)
+    else
+      fragment = self.fragment
+    end
+
     self.class.build({
       scheme: scheme,
       host: host,

--- a/spec/mumukit/application_spec.rb
+++ b/spec/mumukit/application_spec.rb
@@ -2,9 +2,14 @@ require_relative '../spec_helper'
 
 describe Mumukit::Platform::Application do
   it { expect(Mumukit::Platform.laboratory.organic_url_for 'foo', '/foo/baz').to eq 'http://foo.localmumuki.io/foo/baz' }
-  it { expect(Mumukit::Platform.classroom_ui.organic_url_for 'foo', '/foo/baz').to eq 'http://foo.classroom.localmumuki.io/foo/baz' }
-  it { expect(Mumukit::Platform.bibliotheca_ui.url).to eq 'http://bibliotheca.localmumuki.io' }
+
+  it { expect(Mumukit::Platform.classroom_ui.domain).to eq 'classroom.localmumuki.io' }
+  it { expect(Mumukit::Platform.classroom_ui.organic_url_for 'org', '/foo/baz').to eq 'http://org.classroom.localmumuki.io/#/foo/baz' }
+  it { expect(Mumukit::Platform.classroom_ui.url).to eq 'http://classroom.localmumuki.io/#/' }
+
   it { expect(Mumukit::Platform.bibliotheca_ui.domain).to eq 'bibliotheca.localmumuki.io' }
+  it { expect(Mumukit::Platform.bibliotheca_ui.url).to eq 'http://bibliotheca.localmumuki.io/#/' }
+  it { expect(Mumukit::Platform.bibliotheca_ui.organic_url_for 'org', '/foo/baz').to eq 'http://bibliotheca.localmumuki.io/#/foo/baz' }
 
   it { expect(Mumukit::Platform.application.url_for '/bar').to eq 'http://sample.app.com/bar' }
   it { expect(Mumukit::Platform.application.organic_url_for 'orga', '/bar').to eq 'http://orga.sample.app.com/bar' }

--- a/spec/mumukit/application_spec.rb
+++ b/spec/mumukit/application_spec.rb
@@ -21,6 +21,32 @@ describe Mumukit::Platform::Application do
       it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/foo', mapping).organic_url('bar')).to eq 'http://foo.com:3000/foo/bar/' }
       it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/app/', mapping).organic_url_for('an_orga', 'some/long/path')).to eq 'http://foo.com:3000/app/an_orga/some/long/path' }
       it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/another_app/', mapping).organic_url_for('another_orga', 'some/long/path?with=value')).to eq 'http://foo.com:3000/another_app/another_orga/some/long/path?with=value' }
+
+      context 'with fragments' do
+        context 'with fragment-path' do
+          let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/#/classroom/', mapping) }
+
+          it { expect(fragmented.url).to eq 'http://foo.com:3000/#/classroom/' }
+
+          it { expect(fragmented.organic_url('org')).to eq 'http://foo.com:3000/#/classroom/org/' }
+
+          it { expect(fragmented.organic_url_for('org', 'path')).to eq 'http://foo.com:3000/#/classroom/org/path' }
+          it { expect(fragmented.organic_url_for('org', '/path')).to eq 'http://foo.com:3000/#/classroom/org/path' }
+          it { expect(fragmented.organic_url_for('org', 'path/other')).to eq 'http://foo.com:3000/#/classroom/org/path/other' }
+        end
+
+        context 'without fragment-path' do
+          let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/#', mapping) }
+
+          it { expect(fragmented.url).to eq 'http://foo.com:3000/#' }
+
+          it { expect(fragmented.organic_url('org')).to eq 'http://foo.com:3000/#/org/' }
+
+          it { expect(fragmented.organic_url_for('org', 'path')).to eq 'http://foo.com:3000/#/org/path' }
+          it { expect(fragmented.organic_url_for('org', '/path')).to eq 'http://foo.com:3000/#/org/path' }
+          it { expect(fragmented.organic_url_for('org', 'path/other')).to eq 'http://foo.com:3000/#/org/path/other' }
+        end
+      end
     end
   end
 end

--- a/spec/mumukit/uri_spec.rb
+++ b/spec/mumukit/uri_spec.rb
@@ -1,19 +1,27 @@
 require 'spec_helper'
 
-def add_extra_subdomain(original_url)
-  URI(original_url).subdominate('extra').to_s
+def add_extra_subdomain(original_url, **options)
+  URI(original_url).subdominate('extra', **options).to_s
 end
 
-def add_extra_path(original_url)
-  URI(original_url).tenantize('extra').to_s
+def add_extra_path(original_url, **options)
+  URI(original_url).tenantize('extra', **options).to_s
 end
 
 describe URI do
   describe '#subdominate' do
     it { expect(add_extra_subdomain('https://foo.bar')).to eq 'https://extra.foo.bar' }
     it { expect(add_extra_subdomain('http://foo.bar')).to eq 'http://extra.foo.bar' }
-    it { expect(add_extra_subdomain('http://foo.bar/zaraza')).to eq 'http://extra.foo.bar/zaraza' }
-    it { expect(add_extra_subdomain('http://foo.bar/#zaraza')).to eq 'http://extra.foo.bar/#zaraza' }
+    it { expect(add_extra_subdomain('http://foo.bar/foo')).to eq 'http://extra.foo.bar/foo' }
+
+    it { expect(add_extra_subdomain('http://foo.bar/#')).to eq 'http://extra.foo.bar/#' }
+    it { expect(add_extra_subdomain('http://foo.bar/#', fragmented: true)).to eq 'http://extra.foo.bar/#/' }
+    it { expect(add_extra_subdomain('http://foo.bar/#/', fragmented: true)).to eq 'http://extra.foo.bar/#/' }
+
+    it { expect(add_extra_subdomain('http://foo.bar/#foo')).to eq 'http://extra.foo.bar/#foo' }
+    it { expect(add_extra_subdomain('http://foo.bar/#/foo')).to eq 'http://extra.foo.bar/#/foo' }
+    it { expect(add_extra_subdomain('http://foo.bar/#foo', fragmented: true)).to eq 'http://extra.foo.bar/#foo/' }
+    it { expect(add_extra_subdomain('http://foo.bar/#/foo', fragmented: true)).to eq 'http://extra.foo.bar/#/foo/' }
 
     it { expect(add_extra_subdomain('http://www.foo.bar.com/')).to eq 'http://www.extra.foo.bar.com/' }
     it { expect(add_extra_subdomain('http://foo.bar.com/foo?z=3')).to eq 'http://extra.foo.bar.com/foo?z=3' }
@@ -22,7 +30,16 @@ describe URI do
   describe '#tenantize' do
     it { expect(add_extra_path('https://foo.bar')).to eq 'https://foo.bar/extra/' }
     it { expect(add_extra_path('http://foo.bar')).to eq 'http://foo.bar/extra/' }
-    it { expect(add_extra_path('http://foo.bar/zaraza')).to eq 'http://foo.bar/zaraza/extra/' }
+    it { expect(add_extra_path('http://foo.bar/foo')).to eq 'http://foo.bar/foo/extra/' }
+
+    it { expect(add_extra_path('http://foo.bar/#')).to eq 'http://foo.bar/extra/#' }
+    it { expect(add_extra_path('http://foo.bar/#', fragmented: true)).to eq 'http://foo.bar/#/extra/' }
+    it { expect(add_extra_path('http://foo.bar/#/', fragmented: true)).to eq 'http://foo.bar/#/extra/' }
+
+    it { expect(add_extra_path('http://foo.bar/#foo')).to eq 'http://foo.bar/extra/#foo' }
+    it { expect(add_extra_path('http://foo.bar/#/foo')).to eq 'http://foo.bar/extra/#/foo' }
+    it { expect(add_extra_path('http://foo.bar/#foo', fragmented: true)).to eq 'http://foo.bar/#foo/extra/' }
+    it { expect(add_extra_path('http://foo.bar/#/foo', fragmented: true)).to eq 'http://foo.bar/#/foo/extra/' }
 
     it { expect(add_extra_path('http://foo.bar.com/')).to eq 'http://foo.bar.com/extra/' }
     it { expect(add_extra_path('http://foo.bar.com/foo')).to eq 'http://foo.bar.com/foo/extra/' }


### PR DESCRIPTION
# :dart: Goal

To create the "definitive" fix to the classroom and bibliotheca _fragmented_ urls

# :memo: Details

With this change, if an application URL contains a fragment, it will be automatically interpret paths as _fragment-path_, and join them and create organic urls accordingly. 

# :back: Backward compatibility

In order to make this code work, classroom and bibliotheca env variables will have to change. There is no warranty this code will work with previous custom assumptions.   

# :warning: Dependencies

Depends on https://github.com/mumuki/mumukit-platform/pull/42. There is no real need for that, I think we should merge both PRs now.  

