### PR TITLE
Move url_for logic to URI

### DIFF
--- a/lib/mumukit/platform/application.rb
+++ b/lib/mumukit/platform/application.rb
@@ -27,16 +27,10 @@ class Mumukit::Platform::Application
     uri.url_for(path) if path
   end
 
+  # warning: this code is tightly coupled to the fact that
+  # applications can only rebuild urls in fragmented-mode
   def organic_url_for(organization, path)
-    uri = organic_uri(organization)
-    # warning: this code is tightly
-    # coupled to the fact that applications can only rebuild urls
-    # in fragmented-mode
-    if uri.fragment
-      uri.to_s + relative_path(path)
-    else
-      uri.url_for(relative_path path)
-    end
+    organic_uri(organization).url_for(relative_path path)
   end
 
   def relative_path(path)

--- a/lib/mumukit/platform/uri.rb
+++ b/lib/mumukit/platform/uri.rb
@@ -35,6 +35,10 @@ class URI::HTTP
   end
 
   def url_for(path)
-    URI.join(self, path).to_s
+    if fragment
+      to_s + path
+    else
+      URI.join(self, path).to_s
+    end
   end
 end


### PR DESCRIPTION
@flbulgarelli Is there a reason why you didn't move that logic into URI?

This would come in handy if we ever want to redefine organic_url :grin: 