### PR TITLE
Fix prefragment routes

### DIFF
--- a/lib/mumukit/platform/uri.rb
+++ b/lib/mumukit/platform/uri.rb
@@ -8,13 +8,15 @@ class URI::HTTP
     rebuild({host: new_host}, **options)
   end
 
-  def tenantize(route, **options)
-    if path.end_with? '/'
+  def tenantize(route, fragmented: false)
+    if fragmented && fragment
+      new_path = route
+    elsif path.end_with? '/'
       new_path = "#{path}#{route}/"
     else
       new_path = "#{path}/#{route}/"
     end
-    rebuild({path: new_path}, **options)
+    rebuild({path: new_path}, fragmented: fragmented)
   end
 
   def rebuild(updates, fragmented: false)

--- a/spec/mumukit/application_spec.rb
+++ b/spec/mumukit/application_spec.rb
@@ -28,6 +28,18 @@ describe Mumukit::Platform::Application do
       it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/another_app/', mapping).organic_url_for('another_orga', 'some/long/path?with=value')).to eq 'http://foo.com:3000/another_app/another_orga/some/long/path?with=value' }
 
       context 'with fragments' do
+        context 'with prefragment-path' do
+          let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/classroom/#/', mapping) }
+
+          it { expect(fragmented.url).to eq 'http://foo.com:3000/classroom/#/' }
+
+          it { expect(fragmented.organic_url('org')).to eq 'http://foo.com:3000/classroom/#/org/' }
+
+          it { expect(fragmented.organic_url_for('org', 'path')).to eq 'http://foo.com:3000/classroom/#/org/path' }
+          it { expect(fragmented.organic_url_for('org', '/path')).to eq 'http://foo.com:3000/classroom/#/org/path' }
+          it { expect(fragmented.organic_url_for('org', 'path/other')).to eq 'http://foo.com:3000/classroom/#/org/path/other' }
+        end
+
         context 'with fragment-path' do
           let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/#/classroom/', mapping) }
 


### PR DESCRIPTION
# :dart: Goal

To make organic fragmented urls manipulation work when using a path before the fragment. 

# :memo: Details

Let's call these urls _prefragmented_ urls.    