### PR TITLE
Chore untenantize

### DIFF
--- a/lib/mumukit/platform/application.rb
+++ b/lib/mumukit/platform/application.rb
@@ -47,6 +47,10 @@ class Mumukit::Platform::Application
     def organic_uri(_organization)
       uri
     end
+
+    def retenantize_in(organization, tenantized_path)
+      organic_url_for(organization, tenantized_path)
+    end
   end
 
   class Organic < Mumukit::Platform::Application
@@ -55,6 +59,11 @@ class Mumukit::Platform::Application
     def initialize(url, organization_mapping)
       super(url)
       @organization_mapping = organization_mapping
+    end
+
+    def retenantize_in(organization, tenantized_path)
+      untenantized_path = organization_mapping.untenantize(tenantized_path)
+      organic_url_for(organization, untenantized_path)
     end
 
     def organic_uri(organization)

--- a/lib/mumukit/platform/organization_mapping.rb
+++ b/lib/mumukit/platform/organization_mapping.rb
@@ -52,10 +52,6 @@ module Mumukit::Platform::OrganizationMapping
     def self.path_under_namespace?(_organization_name, path, namespace)
       path.start_with? "/#{namespace}/"
     end
-
-    def self.inorganic_path_for(request)
-      path_for(request)
-    end
   end
 
   module Path
@@ -76,10 +72,6 @@ module Mumukit::Platform::OrganizationMapping
 
     def self.organization_name(request, _domain)
       path_composition_for(path_for(request)).first
-    end
-
-    def self.inorganic_path_for(request)
-      untenantize path_for(request)
     end
 
     def self.organic_uri(uri, organization)

--- a/lib/mumukit/platform/organization_mapping.rb
+++ b/lib/mumukit/platform/organization_mapping.rb
@@ -24,6 +24,10 @@ module Mumukit::Platform::OrganizationMapping
     def path_for(request)
       request.path_info
     end
+
+    def untenantize(path)
+      path
+    end
   end
 
   module Subdomain
@@ -65,17 +69,17 @@ module Mumukit::Platform::OrganizationMapping
       framework.configure_tenant_path_routes! native, &block
     end
 
-    def self.path_composition_for(request)
-      organization, *path_parts = Pathname(path_for(request)).each_filename.to_a
+    def self.path_composition_for(path)
+      organization, *path_parts = Pathname(path).each_filename.to_a
       [organization, path_parts.join('/')]
     end
 
     def self.organization_name(request, _domain)
-      path_composition_for(request).first
+      path_composition_for(path_for(request)).first
     end
 
     def self.inorganic_path_for(request)
-      path_composition_for(request).second
+      untenantize path_for(request)
     end
 
     def self.organic_uri(uri, organization)
@@ -84,6 +88,10 @@ module Mumukit::Platform::OrganizationMapping
 
     def self.path_under_namespace?(organization_name, path, namespace)
       path.start_with? "/#{organization_name}/#{namespace}/"
+    end
+
+    def self.untenantize(path)
+      path_composition_for(path).second
     end
   end
 end

--- a/spec/mumukit/application_spec.rb
+++ b/spec/mumukit/application_spec.rb
@@ -2,6 +2,7 @@ require_relative '../spec_helper'
 
 describe Mumukit::Platform::Application do
   it { expect(Mumukit::Platform.laboratory.organic_url_for 'foo', '/foo/baz').to eq 'http://foo.localmumuki.io/foo/baz' }
+  it { expect(Mumukit::Platform.laboratory.retenantize_in 'an-orga', '/a_path').to eq 'http://an-orga.localmumuki.io/a_path' }
 
   it { expect(Mumukit::Platform.classroom_ui.domain).to eq 'classroom.localmumuki.io' }
   it { expect(Mumukit::Platform.classroom_ui.organic_url_for 'org', '/foo/baz').to eq 'http://org.classroom.localmumuki.io/#/foo/baz' }
@@ -17,19 +18,21 @@ describe Mumukit::Platform::Application do
   describe Mumukit::Platform::Application::Basic do
     context 'with subdomain mapping strategy' do
       let(:mapping) { Mumukit::Platform::OrganizationMapping::Subdomain }
-      it { expect(Mumukit::Platform::Application::Basic.new('http://foo.com:3000').organic_url('org')).to eq 'http://foo.com:3000' }
+      it { expect(new_basic_app('http://foo.com:3000').organic_url('org')).to eq 'http://foo.com:3000' }
+      it { expect(new_basic_app('http://foo.com:3000').retenantize_in('other-orga', '/an-orga/deep')).to eq 'http://foo.com:3000/an-orga/deep' }
     end
 
     context 'with path mapping strategy' do
       let(:mapping) { Mumukit::Platform::OrganizationMapping::Path }
-      it { expect(Mumukit::Platform::Application::Basic.new('http://foo.com:3000').organic_url('org')).to eq 'http://foo.com:3000' }
-      it { expect(Mumukit::Platform::Application::Basic.new('http://foo.com:3000/foo').organic_url('org')).to eq 'http://foo.com:3000/foo' }
-      it { expect(Mumukit::Platform::Application::Basic.new('http://foo.com:3000/app/').organic_url_for('an_org', 'some/long/path')).to eq 'http://foo.com:3000/app/some/long/path' }
-      it { expect(Mumukit::Platform::Application::Basic.new('http://foo.com:3000/another_app/').organic_url_for('another_org', 'some/long/path?with=value')).to eq 'http://foo.com:3000/another_app/some/long/path?with=value' }
+      it { expect(new_basic_app('http://foo.com:3000').organic_url('org')).to eq 'http://foo.com:3000' }
+      it { expect(new_basic_app('http://foo.com:3000/foo').organic_url('org')).to eq 'http://foo.com:3000/foo' }
+      it { expect(new_basic_app('http://foo.com:3000/app/').organic_url_for('an_org', 'some/long/path')).to eq 'http://foo.com:3000/app/some/long/path' }
+      it { expect(new_basic_app('http://foo.com:3000/another_app/').organic_url_for('another_org', 'some/long/path?with=value')).to eq 'http://foo.com:3000/another_app/some/long/path?with=value' }
+      it { expect(new_basic_app('http://foo.com:3000').retenantize_in('other-orga', '/an-orga/deep')).to eq 'http://foo.com:3000/an-orga/deep' }
 
       context 'with fragments' do
         context 'with prefragment-path' do
-          let(:fragmented) { Mumukit::Platform::Application::Basic.new('http://foo.com:3000/bibliotheca/#/') }
+          let(:fragmented) { new_basic_app('http://foo.com:3000/bibliotheca/#/') }
 
           it { expect(fragmented.url).to eq 'http://foo.com:3000/bibliotheca/#/' }
 
@@ -41,7 +44,7 @@ describe Mumukit::Platform::Application do
         end
 
         context 'with fragment-path' do
-          let(:fragmented) { Mumukit::Platform::Application::Basic.new('http://foo.com:3000/#/bibliotheca/') }
+          let(:fragmented) { new_basic_app('http://foo.com:3000/#/bibliotheca/') }
 
           it { expect(fragmented.url).to eq 'http://foo.com:3000/#/bibliotheca/' }
 
@@ -53,7 +56,7 @@ describe Mumukit::Platform::Application do
         end
 
         context 'without fragment-path' do
-          let(:fragmented) { Mumukit::Platform::Application::Basic.new('http://foo.com:3000/#') }
+          let(:fragmented) { new_basic_app('http://foo.com:3000/#') }
 
           it { expect(fragmented.url).to eq 'http://foo.com:3000/#' }
 
@@ -71,19 +74,21 @@ describe Mumukit::Platform::Application do
   describe Mumukit::Platform::Application::Organic do
     context 'with subdomain mapping strategy' do
       let(:mapping) { Mumukit::Platform::OrganizationMapping::Subdomain }
-      it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000', mapping).organic_url('bar')).to eq 'http://bar.foo.com:3000' }
+      it { expect(new_organic_app('http://foo.com:3000', mapping).organic_url('bar')).to eq 'http://bar.foo.com:3000' }
+      it { expect(new_organic_app('http://foo.com:3000', mapping).retenantize_in('bar', '/a_path/deep')).to eq 'http://bar.foo.com:3000/a_path/deep' }
     end
 
     context 'with path mapping strategy' do
       let(:mapping) { Mumukit::Platform::OrganizationMapping::Path }
-      it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000', mapping).organic_url('org')).to eq 'http://foo.com:3000/org/' }
-      it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/foo', mapping).organic_url('org')).to eq 'http://foo.com:3000/foo/org/' }
-      it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/app/', mapping).organic_url_for('an_org', 'some/long/path')).to eq 'http://foo.com:3000/app/an_org/some/long/path' }
-      it { expect(Mumukit::Platform::Application::Organic.new('http://foo.com:3000/another_app/', mapping).organic_url_for('another_org', 'some/long/path?with=value')).to eq 'http://foo.com:3000/another_app/another_org/some/long/path?with=value' }
+      it { expect(new_organic_app('http://foo.com:3000', mapping).organic_url('org')).to eq 'http://foo.com:3000/org/' }
+      it { expect(new_organic_app('http://foo.com:3000/foo', mapping).organic_url('org')).to eq 'http://foo.com:3000/foo/org/' }
+      it { expect(new_organic_app('http://foo.com:3000/app/', mapping).organic_url_for('an_org', 'some/long/path')).to eq 'http://foo.com:3000/app/an_org/some/long/path' }
+      it { expect(new_organic_app('http://foo.com:3000/another_app/', mapping).organic_url_for('another_org', 'some/long/path?with=value')).to eq 'http://foo.com:3000/another_app/another_org/some/long/path?with=value' }
+      it { expect(new_organic_app('http://foo.com:3000', mapping).retenantize_in('other_orga', '/an_orga/deep')).to eq 'http://foo.com:3000/other_orga/deep' }
 
       context 'with fragments' do
         context 'with prefragment-path' do
-          let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/classroom/#/', mapping) }
+          let(:fragmented) { new_organic_app('http://foo.com:3000/classroom/#/', mapping) }
 
           it { expect(fragmented.url).to eq 'http://foo.com:3000/classroom/#/' }
 
@@ -95,7 +100,7 @@ describe Mumukit::Platform::Application do
         end
 
         context 'with fragment-path' do
-          let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/#/classroom/', mapping) }
+          let(:fragmented) { new_organic_app('http://foo.com:3000/#/classroom/', mapping) }
 
           it { expect(fragmented.url).to eq 'http://foo.com:3000/#/classroom/' }
 
@@ -107,7 +112,7 @@ describe Mumukit::Platform::Application do
         end
 
         context 'without fragment-path' do
-          let(:fragmented) { Mumukit::Platform::Application::Organic.new('http://foo.com:3000/#', mapping) }
+          let(:fragmented) { new_organic_app('http://foo.com:3000/#', mapping) }
 
           it { expect(fragmented.url).to eq 'http://foo.com:3000/#' }
 
@@ -119,5 +124,11 @@ describe Mumukit::Platform::Application do
         end
       end
     end
+  end
+end
+
+%w(basic organic).each do |app_type|
+  define_method("new_#{app_type}_app") do |*params|
+    "Mumukit::Platform::Application::#{app_type.capitalize}".constantize.new *params
   end
 end

--- a/spec/mumukit/organization_mapping_spec.rb
+++ b/spec/mumukit/organization_mapping_spec.rb
@@ -33,20 +33,17 @@ describe Mumukit::Platform::OrganizationMapping do
     context 'on non central' do
       let(:request) { new_rack_request 'http', 'foo.something.com', '80', '/bar/other' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'foo' }
-      it { expect(subject.inorganic_path_for(request)).to eq '/bar/other' }
     end
 
     context 'on explicit central' do
       let(:request) { new_rack_request 'http', 'central.something.com', '80', '/bar/res' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'central' }
-      it { expect(subject.inorganic_path_for(request)).to eq '/bar/res' }
       it { expect(subject.implicit_organization?(request, 'something.com')).to be false }
     end
 
     context 'on implicit central' do
       let(:request) { new_rack_request 'http', 'something.com', '80', '/bar/other' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'central' }
-      it { expect(subject.inorganic_path_for(request)).to eq '/bar/other' }
       it { expect(subject.implicit_organization?(request, 'something.com')).to be true }
     end
   end
@@ -69,30 +66,25 @@ describe Mumukit::Platform::OrganizationMapping do
     context 'on non central' do
       let(:request) { new_rack_request 'http', 'something.com', '80', '/foo' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'foo' }
-      it { expect(subject.inorganic_path_for(request)).to eq '' }
     end
 
     context 'on non central with extra path' do
       let(:request) { new_rack_request 'http', 'something.com', '80', '/foo/bar' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'foo' }
-      it { expect(subject.inorganic_path_for(request)).to eq 'bar' }
     end
 
     context 'on non central with extra path and params' do
       let(:request) { new_rack_request 'http', 'something.com', '80', '/foo/bar/other?param=val' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'foo' }
-      it { expect(subject.inorganic_path_for(request)).to eq 'bar/other?param=val' }
     end
 
     context 'on non central with trailing slash' do
       let(:request) { new_rack_request 'http', 'something.com', '80', '/foo/' }
-      it { expect(subject.inorganic_path_for(request)).to eq '' }
     end
 
     context 'on central' do
       let(:request) { new_rack_request 'http', 'something.com', '80', '/central/' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'central' }
-      it { expect(subject.inorganic_path_for(request)).to eq '' }
     end
   end
 end

--- a/spec/mumukit/organization_mapping_spec.rb
+++ b/spec/mumukit/organization_mapping_spec.rb
@@ -26,6 +26,10 @@ describe Mumukit::Platform::OrganizationMapping do
       it { expect(subject.path_under_namespace? 'central', '/central/foo/bar', 'central').to be true }
     end
 
+    describe '#untenantize' do
+      it { expect(subject.untenantize('/a_route/nested/deep')).to eq '/a_route/nested/deep' }
+    end
+
     context 'on non central' do
       let(:request) { new_rack_request 'http', 'foo.something.com', '80', '/bar/other' }
       it { expect(subject.organization_name(request, 'something.com')).to eq 'foo' }
@@ -55,6 +59,11 @@ describe Mumukit::Platform::OrganizationMapping do
       it { expect(subject.path_under_namespace? 'central', '/central/foo/bar', 'central').to be false }
       it { expect(subject.path_under_namespace? 'central', '/central/foo/bar', 'bar').to be false }
       it { expect(subject.path_under_namespace? 'central', '/central/foo/bar', 'baz').to be false }
+    end
+
+    describe '#untenantize' do
+      it { expect(subject.untenantize('/orga/a_route/nested/deep')).to eq 'a_route/nested/deep' }
+      it { expect(subject.untenantize('/orga')).to eq '' }
     end
 
     context 'on non central' do


### PR DESCRIPTION
Introduce `retenantize_in` for apps (with real benefits on organic apps), which receives an organization and a `tenantized_path` and returns that path "retenantized".

Introduce `untenantize` method which receives a path and returns that path without the organization part of the route.
I could have implemented without adding a new method, but I needed to keep the other methods that receive a request because it's an interface that's still being used across other apps 

Also I'm dropping inorganic_path_for that it is not required anymore